### PR TITLE
added re-render in hideshow

### DIFF
--- a/latex2edx/latex2edx.js
+++ b/latex2edx/latex2edx.js
@@ -41,9 +41,20 @@ function hideshownocheck(object) {
       newclass = arrowclass.replace('up', 'down');
       $(arrow).attr('class', newclass);
   } else {
-      $(stuff).slideDown('slow');
+      $(stuff).slideDown('slow',rerenderMathJax());
       $(text).html('<a href="javascript: {return false;}">Hide</a>');
       newclass = arrowclass.replace('down', 'up');
       $(arrow).attr('class', newclass);
   }
+}
+
+function rerenderMathJax() {
+    try{
+        if (window.MathJax){
+            MathJax.Hub.Queue(["Rerender",MathJax.Hub,".hideshowcontent"]);
+            console.log('here it comes')
+        }
+    }catch (e) {
+        console.log(e)
+    }
 }


### PR DESCRIPTION
Within an element that has `display:none`  set, the browser does not compute the sizes of the sub-elements, and so MathJax can't tell how big anything is So in Show hide div Mathjax is not able to render Math text properly

The current change does not mess with any existing code workings.

There might be an other solution with css changes that will require  lot of code change .